### PR TITLE
updates to prep demand scaffolding fn

### DIFF
--- a/src/aibs_informatics_aws_lambda/handlers/batch/model.py
+++ b/src/aibs_informatics_aws_lambda/handlers/batch/model.py
@@ -14,11 +14,13 @@ if TYPE_CHECKING:  # pragma: no cover
     from mypy_boto3_batch.type_defs import (
         MountPointTypeDef,
         ResourceRequirementTypeDef,
+        RetryStrategyTypeDef,
         VolumeTypeDef,
     )
 else:
     MountPointTypeDef = dict
     ResourceRequirementTypeDef = dict
+    RetryStrategyTypeDef = dict
     VolumeTypeDef = dict
 
 
@@ -26,13 +28,13 @@ else:
 class CreateDefinitionAndPrepareArgsRequest(SchemaModel):
     image: str = custom_field()
     job_definition_name: str = custom_field()
+    job_queue_name: str = custom_field()
     job_name: Optional[str] = custom_field(default=None)
-    job_queue_name: Optional[str] = custom_field(default=None)
     command: List[str] = custom_field(default_factory=list)
     environment: Dict[str, str] = custom_field(default_factory=dict)
     job_definition_tags: Dict[str, str] = custom_field(default_factory=dict)
-    resource_requirements: List[
-        Union[ResourceRequirementTypeDef, ResourceRequirements]
+    resource_requirements: Union[
+        List[ResourceRequirementTypeDef], ResourceRequirements
     ] = custom_field(
         default_factory=list,
         mm_field=UnionField(
@@ -44,6 +46,7 @@ class CreateDefinitionAndPrepareArgsRequest(SchemaModel):
     )
     mount_points: List[MountPointTypeDef] = custom_field(default_factory=list)
     volumes: List[VolumeTypeDef] = custom_field(default_factory=list)
+    retry_strategy: Optional[RetryStrategyTypeDef] = custom_field(default=None)
 
 
 @dataclass

--- a/src/aibs_informatics_aws_lambda/handlers/demand/__init__.py
+++ b/src/aibs_informatics_aws_lambda/handlers/demand/__init__.py
@@ -1,0 +1,5 @@
+__all__ = [
+    "scaffolding_handler",
+]
+
+from aibs_informatics_aws_lambda.handlers.demand.scaffolding import handler as scaffolding_handler

--- a/src/aibs_informatics_aws_lambda/handlers/demand/context_manager.py
+++ b/src/aibs_informatics_aws_lambda/handlers/demand/context_manager.py
@@ -4,7 +4,7 @@ import re
 from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 from aibs_informatics_aws_utils.batch import (
     BatchJobBuilder,
@@ -30,8 +30,6 @@ from aibs_informatics_core.models.aws.efs import EFSPath
 from aibs_informatics_core.models.aws.s3 import S3URI
 from aibs_informatics_core.models.data_sync import PrepareBatchDataSyncRequest
 from aibs_informatics_core.models.demand_execution import DemandExecution
-
-# from aibs_informatics_core.models.demand_priority import DemandPriority
 from aibs_informatics_core.models.demand_execution.resolvables import Resolvable, Uploadable
 from aibs_informatics_core.utils.hashing import sha256_hexdigest
 from aibs_informatics_core.utils.os_operations import write_env_file
@@ -377,12 +375,21 @@ def get_batch_efs_configuration(
     # TODO: add support for file_system_name (learn how to resolve file system name)
     if file_system_name:
         file_system_name = env_base.get_resource_name(file_system_name)
-
-    file_system = get_efs_file_system(name=file_system_name)
-    logger.info(f"Using file system {file_system}")
+        file_system = get_efs_file_system(name=file_system_name, tags={"env_base": env_base})
+        file_system_id = file_system["FileSystemId"]
+        logger.info(
+            f"Using file system {file_system_id} with name {file_system_name}. "
+            f"Will search for access point {access_point_name}."
+        )
+    else:
+        logger.info(
+            f"No file system name provided. "
+            f"Will search for access point {access_point_name} directly."
+        )
+        file_system_id = None
 
     access_point = get_efs_access_point(
-        file_system_id=file_system["FileSystemId"],
+        file_system_id=file_system_id,
         access_point_name=access_point_name,
         access_point_tags={"env_base": env_base},
     )

--- a/src/aibs_informatics_aws_lambda/handlers/demand/model.py
+++ b/src/aibs_informatics_aws_lambda/handlers/demand/model.py
@@ -1,0 +1,66 @@
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from aibs_informatics_core.models.base import SchemaModel, custom_field
+from aibs_informatics_core.models.data_sync import DataSyncRequest
+from aibs_informatics_core.models.demand_execution import DemandExecution
+
+from aibs_informatics_aws_lambda.handlers.batch.model import CreateDefinitionAndPrepareArgsRequest
+from aibs_informatics_aws_lambda.handlers.data_sync import file_system
+
+
+@dataclass
+class CreateDefinitionAndPrepareArgsResponse(SchemaModel):
+    job_name: str = custom_field()
+    job_definition_arn: Optional[str] = custom_field()
+    job_queue_arn: str = custom_field()
+    parameters: Dict[str, Any] = custom_field()
+    container_overrides: Dict[str, Any] = custom_field()
+
+
+@dataclass
+class FileSystemConfiguration(SchemaModel):
+    file_system: Optional[str] = None
+    access_point: Optional[str] = None
+    container_path: Optional[str] = None
+
+
+@dataclass
+class DemandFileSystemConfigurations(SchemaModel):
+    shared: FileSystemConfiguration = custom_field(
+        mm_field=FileSystemConfiguration.as_mm_field(), default_factory=FileSystemConfiguration
+    )
+    scratch: FileSystemConfiguration = custom_field(
+        mm_field=FileSystemConfiguration.as_mm_field(), default_factory=FileSystemConfiguration
+    )
+
+
+@dataclass
+class PrepareDemandScaffoldingRequest(SchemaModel):
+    demand_execution: DemandExecution = custom_field(mm_field=DemandExecution.as_mm_field())
+    file_system_configurations: DemandFileSystemConfigurations = custom_field(
+        mm_field=DemandFileSystemConfigurations.as_mm_field(),
+        default_factory=DemandFileSystemConfigurations,
+    )
+
+
+@dataclass
+class DemandExecutionSetupConfigs(SchemaModel):
+    data_sync_requests: List[DataSyncRequest]
+    batch_create_request: CreateDefinitionAndPrepareArgsRequest
+
+
+@dataclass
+class DemandExecutionCleanupConfigs(SchemaModel):
+    data_sync_requests: List[DataSyncRequest]
+
+
+@dataclass
+class PrepareDemandScaffoldingResponse(SchemaModel):
+    demand_execution: DemandExecution = custom_field(mm_field=DemandExecution.as_mm_field())
+    setup_configs: DemandExecutionSetupConfigs = custom_field(
+        mm_field=DemandExecutionSetupConfigs.as_mm_field()
+    )
+    cleanup_configs: DemandExecutionCleanupConfigs = custom_field(
+        mm_field=DemandExecutionCleanupConfigs.as_mm_field()
+    )

--- a/src/aibs_informatics_aws_lambda/handlers/demand/scaffolding.py
+++ b/src/aibs_informatics_aws_lambda/handlers/demand/scaffolding.py
@@ -1,0 +1,129 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Union
+
+from aibs_informatics_aws_utils.batch import build_retry_strategy
+from aibs_informatics_aws_utils.constants.efs import (
+    EFS_SCRATCH_ACCESS_POINT_NAME,
+    EFS_SCRATCH_PATH,
+    EFS_SHARED_ACCESS_POINT_NAME,
+    EFS_SHARED_PATH,
+)
+from aibs_informatics_aws_utils.efs import MountPointConfiguration
+from aibs_informatics_core.env import EnvBase
+from aibs_informatics_core.models.data_sync import DataSyncRequest
+
+from aibs_informatics_aws_lambda.common.handler import LambdaHandler
+from aibs_informatics_aws_lambda.handlers.demand.context_manager import (
+    BatchEFSConfiguration,
+    DemandExecutionContextManager,
+)
+from aibs_informatics_aws_lambda.handlers.demand.model import (
+    CreateDefinitionAndPrepareArgsRequest,
+    DemandExecutionCleanupConfigs,
+    DemandExecutionSetupConfigs,
+    PrepareDemandScaffoldingRequest,
+    PrepareDemandScaffoldingResponse,
+)
+
+
+@dataclass
+class PrepareDemandScaffoldingHandler(
+    LambdaHandler[PrepareDemandScaffoldingRequest, PrepareDemandScaffoldingResponse]
+):
+    def handle(self, request: PrepareDemandScaffoldingRequest) -> PrepareDemandScaffoldingResponse:
+        scratch_vol_configuration = construct_batch_efs_configuration(
+            env_base=self.env_base,
+            file_system=request.file_system_configurations.scratch.file_system,
+            access_point=request.file_system_configurations.scratch.access_point
+            if request.file_system_configurations.scratch.access_point
+            else EFS_SCRATCH_ACCESS_POINT_NAME,
+            container_path=request.file_system_configurations.scratch.container_path
+            if request.file_system_configurations.scratch.container_path
+            else f"/opt/efs{EFS_SCRATCH_PATH}",
+            read_only=False,
+        )
+
+        shared_vol_configuration = construct_batch_efs_configuration(
+            env_base=self.env_base,
+            file_system=request.file_system_configurations.shared.file_system,
+            access_point=request.file_system_configurations.shared.access_point
+            if request.file_system_configurations.shared.access_point
+            else EFS_SHARED_ACCESS_POINT_NAME,
+            container_path=request.file_system_configurations.shared.container_path
+            if request.file_system_configurations.shared.container_path
+            else f"/opt/efs{EFS_SHARED_PATH}",
+            read_only=True,
+        )
+
+        context_manager = DemandExecutionContextManager(
+            demand_execution=request.demand_execution,
+            scratch_vol_configuration=scratch_vol_configuration,
+            shared_vol_configuration=shared_vol_configuration,
+            env_base=self.env_base,
+        )
+
+        batch_job_builder = context_manager.batch_job_builder
+
+        self.setup_file_system(context_manager)
+        setup_configs = DemandExecutionSetupConfigs(
+            data_sync_requests=[
+                DataSyncRequest.from_dict(_.to_dict())
+                for _ in context_manager.pre_execution_data_sync_requests
+            ],
+            batch_create_request=CreateDefinitionAndPrepareArgsRequest(
+                image=batch_job_builder.image,
+                job_definition_name=batch_job_builder.job_definition_name,
+                job_name=batch_job_builder.job_name,
+                job_queue_name=context_manager.batch_job_queue_name,
+                job_definition_tags=batch_job_builder.job_definition_tags,
+                command=batch_job_builder.command,
+                environment=batch_job_builder.environment,
+                resource_requirements=batch_job_builder.resource_requirements,
+                mount_points=batch_job_builder.mount_points,
+                volumes=batch_job_builder.volumes,
+                retry_strategy=build_retry_strategy(num_retries=5),
+            ),
+        )
+
+        cleanup_configs = DemandExecutionCleanupConfigs(
+            data_sync_requests=[
+                DataSyncRequest.from_dict(_.to_dict())
+                for _ in context_manager.post_execution_data_sync_requests
+            ]
+        )
+
+        return PrepareDemandScaffoldingResponse(
+            demand_execution=context_manager.demand_execution,
+            setup_configs=setup_configs,
+            cleanup_configs=cleanup_configs,
+        )
+
+    def setup_file_system(self, context_manager: DemandExecutionContextManager):
+        """Sets up working directory for file system
+
+        Args:
+            context_manager (DemandExecutionContextManager): context manager
+        """
+        working_path = context_manager.container_working_path
+        # working_path.mkdir(parents=True, exist_ok=True)
+
+
+def construct_batch_efs_configuration(
+    env_base: EnvBase,
+    container_path: Union[Path, str],
+    file_system: Optional[str],
+    access_point: Optional[str],
+    read_only: bool = False,
+) -> BatchEFSConfiguration:
+    mount_point_config = MountPointConfiguration.build(
+        mount_point=container_path,
+        access_point=access_point,
+        file_system=file_system,
+        access_point_tags={"env_base": env_base},
+        file_system_tags={"env_base": env_base},
+    )
+    return BatchEFSConfiguration(mount_point_config=mount_point_config, read_only=read_only)
+
+
+handler = PrepareDemandScaffoldingHandler.get_handler()

--- a/test/aibs_informatics_aws_lambda/handlers/demand/test_scaffolding.py
+++ b/test/aibs_informatics_aws_lambda/handlers/demand/test_scaffolding.py
@@ -1,0 +1,322 @@
+from pathlib import Path
+from test.aibs_informatics_aws_lambda.base import LambdaHandlerTestCase
+from typing import Any, Dict
+from unittest import mock
+
+from aibs_informatics_aws_utils.efs import MountPointConfiguration
+from aibs_informatics_core.models.demand_execution import DemandExecution
+from aibs_informatics_core.models.unique_ids import UniqueID
+
+from aibs_informatics_aws_lambda.common.handler import LambdaHandlerType
+from aibs_informatics_aws_lambda.handlers.batch.model import CreateDefinitionAndPrepareArgsRequest
+from aibs_informatics_aws_lambda.handlers.demand.context_manager import BatchEFSConfiguration
+from aibs_informatics_aws_lambda.handlers.demand.model import (
+    DemandExecutionCleanupConfigs,
+    DemandExecutionSetupConfigs,
+    PrepareDemandScaffoldingResponse,
+)
+from aibs_informatics_aws_lambda.handlers.demand.scaffolding import (
+    PrepareDemandScaffoldingHandler,
+    construct_batch_efs_configuration,
+)
+
+
+class PrepareDemandScaffoldingHandlerTests(LambdaHandlerTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.mock_MountPointConfiguration = self.create_patch(
+            "aibs_informatics_aws_lambda.handlers.demand.scaffolding.MountPointConfiguration"
+        )
+        self.mock_DemandExecutionContextManager = self.create_patch(
+            "aibs_informatics_aws_lambda.handlers.demand.scaffolding.DemandExecutionContextManager"
+        )
+        self.demand_execution = DemandExecution(
+            execution_type="demand",
+            execution_id=UniqueID.create(123),
+            execution_image="image",
+        )
+
+    @property
+    def handler(self) -> LambdaHandlerType:
+        return PrepareDemandScaffoldingHandler.get_handler()
+
+    def test__construct_batch_efs_configuration__works(self) -> None:
+        # Arrange
+        file_system_id = "fs-123456789012"
+        access_point_id = "fsap-123456789012"
+        container_path = "/opt/efs"
+        read_only = False
+        expected_mount_point_config = MountPointConfiguration(
+            file_system={
+                "FileSystemId": file_system_id,  # ID of the EFS file system
+                "CreationToken": "string",  # Unique string to ensure idempotent creation
+                "PerformanceMode": "generalPurpose",  # 'generalPurpose' or 'maxIO'
+                "Encrypted": True,  # or False
+                "KmsKeyId": "string",  # KMS key ID for encryption
+                "ThroughputMode": "bursting",  # 'provisioned' or 'bursting'
+                "ProvisionedThroughputInMibps": 123.0,  # if 'provisioned' is chosen
+                "Tags": [
+                    {"Key": "Name", "Value": "MyEFS"},
+                ],
+            },
+            access_point={
+                "AccessPointId": access_point_id,  # ID of the EFS access point
+                "ClientToken": "string",  # Unique string to ensure idempotent creation
+                "FileSystemId": file_system_id,  # ID of the EFS file system
+                "PosixUser": {"Uid": "1000", "Gid": "1000"},
+                "RootDirectory": {
+                    "Path": "/",
+                    "CreationInfo": {"OwnerUid": "1000", "OwnerGid": "1000", "Permissions": "755"},
+                },
+                "Tags": [
+                    {"Key": "Name", "Value": "MyAccessPoint"},
+                ],
+            },
+            mount_point=Path(container_path),
+        )
+
+        build = mock.MagicMock()
+        self.mock_MountPointConfiguration.build = build
+        build.return_value = expected_mount_point_config
+
+        # Act
+        handler = PrepareDemandScaffoldingHandler()
+        result = construct_batch_efs_configuration(
+            env_base=self.env_base,
+            file_system=file_system_id,
+            access_point=access_point_id,
+            container_path=container_path,
+            read_only=read_only,
+        )
+
+        # Assert
+        self.assertEqual(
+            result.mount_point,
+            {
+                "containerPath": container_path,
+                "readOnly": False,
+                "sourceVolume": "fs-123456789012-opt-efs-vol",
+            },
+        )
+        self.assertEqual(result.read_only, read_only)
+
+    @mock.patch(
+        "aibs_informatics_aws_lambda.handlers.demand.scaffolding.construct_batch_efs_configuration"
+    )
+    def test__handle__simple_case(self, mock_construct_batch_efs_configuration) -> None:
+        mock_construct_batch_efs_configuration.side_effect = (
+            lambda *args, **kwargs: BatchEFSConfiguration(
+                mount_point_config=MountPointConfiguration(
+                    file_system=self.get_file_system("fs-123456789012"),
+                    access_point=self.get_access_point("fsap-123456789012", "fs-123456789012"),
+                    mount_point=Path("/opt/efs"),
+                ),
+                read_only=False,
+            )
+        )
+
+        context_manager = mock.MagicMock()
+        self.mock_DemandExecutionContextManager.return_value = context_manager
+        context_manager.demand_execution = self.demand_execution
+        context_manager.pre_execution_data_sync_requests = []
+        context_manager.post_execution_data_sync_requests = []
+        batch_job_builder = mock.MagicMock()
+        context_manager.batch_job_builder = batch_job_builder
+        context_manager.batch_job_queue_name = "job_queue_name"
+        batch_job_builder.image = "image"
+        batch_job_builder.job_definition_name = "job_definition_name"
+        batch_job_builder.job_name = "job_name"
+        batch_job_builder.job_definition_tags = {}
+        batch_job_builder.command = ["command"]
+        batch_job_builder.environment = {"key": "value"}
+        batch_job_builder.resource_requirements = []
+        batch_job_builder.mount_points = []
+        batch_job_builder.volumes = []
+
+        expected = PrepareDemandScaffoldingResponse(
+            demand_execution=self.demand_execution,
+            setup_configs=DemandExecutionSetupConfigs(
+                data_sync_requests=[],
+                batch_create_request=CreateDefinitionAndPrepareArgsRequest(
+                    image="image",
+                    job_definition_name="job_definition_name",
+                    job_name="job_name",
+                    job_queue_name="job_queue_name",
+                    job_definition_tags={},
+                    command=["command"],
+                    environment={"key": "value"},
+                    resource_requirements=[],
+                    mount_points=[],
+                    volumes=[],
+                    retry_strategy={
+                        "attempts": 5,
+                        "evaluateOnExit": [
+                            {
+                                "action": "RETRY",
+                                "onReason": "DockerTimeoutError*",
+                                "onStatusReason": "Task " "failed " "to " "start",
+                            },
+                            {"action": "RETRY", "onStatusReason": "Host " "EC2*"},
+                            {"action": "EXIT", "onStatusReason": "*"},
+                        ],
+                    },
+                ),
+            ),
+            cleanup_configs=DemandExecutionCleanupConfigs(data_sync_requests=[]),
+        ).to_dict()
+
+        self.assertHandles(
+            self.handler,
+            {
+                "demand_execution": self.demand_execution.to_dict(),
+            },
+            response=expected,
+        )
+        assert mock_construct_batch_efs_configuration.call_args_list == [
+            mock.call(
+                env_base=self.env_base,
+                file_system=None,
+                access_point="scratch",
+                container_path="/opt/efs/scratch",
+                read_only=False,
+            ),
+            mock.call(
+                env_base=self.env_base,
+                file_system=None,
+                access_point="shared",
+                container_path="/opt/efs/shared",
+                read_only=True,
+            ),
+        ]
+
+    @mock.patch(
+        "aibs_informatics_aws_lambda.handlers.demand.scaffolding.construct_batch_efs_configuration"
+    )
+    def test__handle__file_system_overrides(self, mock_construct_batch_efs_configuration) -> None:
+        mock_construct_batch_efs_configuration.side_effect = (
+            lambda *args, **kwargs: BatchEFSConfiguration(
+                mount_point_config=MountPointConfiguration(
+                    file_system=self.get_file_system("fs-123456789012"),
+                    access_point=self.get_access_point("fsap-123456789012", "fs-123456789012"),
+                    mount_point=Path("/opt/efs"),
+                ),
+                read_only=False,
+            )
+        )
+
+        context_manager = mock.MagicMock()
+        self.mock_DemandExecutionContextManager.return_value = context_manager
+        context_manager.demand_execution = self.demand_execution
+        context_manager.pre_execution_data_sync_requests = []
+        context_manager.post_execution_data_sync_requests = []
+        batch_job_builder = mock.MagicMock()
+        context_manager.batch_job_builder = batch_job_builder
+        context_manager.batch_job_queue_name = "job_queue_name"
+        batch_job_builder.image = "image"
+        batch_job_builder.job_definition_name = "job_definition_name"
+        batch_job_builder.job_name = "job_name"
+        batch_job_builder.job_definition_tags = {}
+        batch_job_builder.command = ["command"]
+        batch_job_builder.environment = {"key": "value"}
+        batch_job_builder.resource_requirements = []
+        batch_job_builder.mount_points = []
+        batch_job_builder.volumes = []
+
+        expected = PrepareDemandScaffoldingResponse(
+            demand_execution=self.demand_execution,
+            setup_configs=DemandExecutionSetupConfigs(
+                data_sync_requests=[],
+                batch_create_request=CreateDefinitionAndPrepareArgsRequest(
+                    image="image",
+                    job_definition_name="job_definition_name",
+                    job_name="job_name",
+                    job_queue_name="job_queue_name",
+                    job_definition_tags={},
+                    command=["command"],
+                    environment={"key": "value"},
+                    resource_requirements=[],
+                    mount_points=[],
+                    volumes=[],
+                    retry_strategy={
+                        "attempts": 5,
+                        "evaluateOnExit": [
+                            {
+                                "action": "RETRY",
+                                "onReason": "DockerTimeoutError*",
+                                "onStatusReason": "Task " "failed " "to " "start",
+                            },
+                            {"action": "RETRY", "onStatusReason": "Host " "EC2*"},
+                            {"action": "EXIT", "onStatusReason": "*"},
+                        ],
+                    },
+                ),
+            ),
+            cleanup_configs=DemandExecutionCleanupConfigs(data_sync_requests=[]),
+        ).to_dict()
+
+        self.assertHandles(
+            self.handler,
+            {
+                "demand_execution": self.demand_execution.to_dict(),
+                "file_system_configurations": {
+                    "scratch": {
+                        "file_system": "fs-123456789012",
+                        "access_point": "fsap-123456789012",
+                        "container_path": "/opt/efs/anotherscratch",
+                    },
+                    "shared": {
+                        "file_system": "fs-123456789012",
+                        "access_point": "fsap-1234567890123",
+                        "container_path": "/opt/efs/anothershared",
+                    },
+                },
+            },
+            response=expected,
+        )
+        assert mock_construct_batch_efs_configuration.call_args_list == [
+            mock.call(
+                env_base=self.env_base,
+                file_system="fs-123456789012",
+                access_point="fsap-123456789012",
+                container_path="/opt/efs/anotherscratch",
+                read_only=False,
+            ),
+            mock.call(
+                env_base=self.env_base,
+                file_system="fs-123456789012",
+                access_point="fsap-1234567890123",
+                container_path="/opt/efs/anothershared",
+                read_only=True,
+            ),
+        ]
+
+    def get_file_system(self, file_system_id: str) -> Dict[str, Any]:
+        return {
+            "FileSystemId": file_system_id,  # ID of the EFS file system
+            "CreationToken": "string",  # Unique string to ensure idempotent creation
+            "PerformanceMode": "generalPurpose",  # 'generalPurpose' or 'maxIO'
+            "Encrypted": True,  # or False
+            "KmsKeyId": "string",  # KMS key ID for encryption
+            "ThroughputMode": "bursting",  # 'provisioned' or 'bursting'
+            "ProvisionedThroughputInMibps": 123.0,  # if 'provisioned' is chosen
+            "Tags": [
+                {"Key": "Name", "Value": "MyEFS"},
+            ],
+        }
+
+    def get_access_point(
+        self, access_point_id: str, file_system_id: str, **tags
+    ) -> Dict[str, Any]:
+        return {
+            "AccessPointId": access_point_id,  # ID of the EFS access point
+            "ClientToken": "string",  # Unique string to ensure idempotent creation
+            "FileSystemId": file_system_id,  # ID of the EFS file system
+            "PosixUser": {"Uid": "1000", "Gid": "1000"},
+            "RootDirectory": {
+                "Path": "/",
+                "CreationInfo": {"OwnerUid": "1000", "OwnerGid": "1000", "Permissions": "755"},
+            },
+            "Tags": [
+                {"Key": "Name", "Value": "value"},
+            ],
+        }


### PR DESCRIPTION
## What's in this Change?

This contains updates to the prepare-demand-scaffolding lambda function.  

* adding option to specify file system configurations for shared and scratch directories
* adding unit tests
* changing logic in create batch job def and prep args
  * allowing certain public images as they are (previously considered private if not valid ecr uri) 

## Testing

<!-- Add any automated/manual test steps that you have run to confirm the changes -->

