### PR TITLE
add support for s3 references to batch data sync requests

### DIFF
--- a/src/aibs_informatics_aws_lambda/handlers/data_sync/operations.py
+++ b/src/aibs_informatics_aws_lambda/handlers/data_sync/operations.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import List, Optional, Union, cast
 
 from aibs_informatics_aws_utils.data_sync import (
     DataSyncOperations,
@@ -122,7 +122,15 @@ class BatchDataSyncHandler(LambdaHandler[BatchDataSyncRequest, BatchDataSyncResp
     def handle(self, request: BatchDataSyncRequest) -> BatchDataSyncResponse:
         self.logger.info(f"Received {len(request.requests)} requests to transfer")
         responses = []
-        for _ in request.requests:
+        if isinstance(request.requests, S3URI):
+            self.logger.info(f"Request is stored at {request.requests}... fetching content.")
+            _ = download_to_json(request.requests)
+            assert isinstance(_, list)
+            batch_requests = [DataSyncRequest.from_dict(__) for __ in _]
+        else:
+            batch_requests = request.requests
+
+        for _ in batch_requests:
             sync_operations = DataSyncOperations(_)
             self.logger.info(f"Syncing content from {_.source_path} to {_.destination_path}")
             sync_operations.sync(
@@ -170,7 +178,20 @@ class PrepareBatchDataSyncHandler(
                     )
                 )
             batch_data_sync_requests.append(BatchDataSyncRequest(requests=data_sync_requests))
-        return PrepareBatchDataSyncResponse(requests=batch_data_sync_requests)
+
+        if request.intermediate_s3_path:
+            self.logger.info(f"Uploading batch requests to {request.intermediate_s3_path}")
+            new_batch_data_sync_requests = []
+
+            for i, batch_data_sync_request in enumerate(batch_data_sync_requests):
+                upload_json(
+                    [cast(DataSyncRequest, _).to_dict() for _ in batch_data_sync_request.requests],
+                    s3_path=(s3_path := request.intermediate_s3_path / f"request_{i}.json"),
+                )
+                new_batch_data_sync_requests.append(BatchDataSyncRequest(requests=s3_path))
+            return PrepareBatchDataSyncResponse(requests=new_batch_data_sync_requests)
+        else:
+            return PrepareBatchDataSyncResponse(requests=batch_data_sync_requests)
 
     @classmethod
     def build_source_path(


### PR DESCRIPTION
## What's in this Change?

* adding support for storing batch data sync requests to s3 and fetching pointers to such objects in a request. 

Why is this needed? there is a rather small max payload allowed in step functions (256 KB). This is problematic for our lambda and batch lambda functions that are plugged into the system. This change allows us to write part of the larger parts of the lambda responses and requests to s3 and load it. 

The way it works is that if you specify `intermediate_s3_path` in the prepare batch data sync request, the function will write the batch data sync requests to s3 objects under that path specified.  

## Testing
* running e2e tests in merscope analysis pipeline
