### PR TITLE
add privileged to batch job builder

### DIFF
--- a/src/aibs_informatics_aws_lambda/handlers/batch/create.py
+++ b/src/aibs_informatics_aws_lambda/handlers/batch/create.py
@@ -62,6 +62,7 @@ class CreateDefinitionAndPrepareArgsHandler(
             resource_requirements=request.resource_requirements,
             mount_points=request.mount_points,
             volumes=request.volumes,
+            privileged=request.privileged,
         )
 
         response = register_job_definition(

--- a/src/aibs_informatics_aws_lambda/handlers/batch/model.py
+++ b/src/aibs_informatics_aws_lambda/handlers/batch/model.py
@@ -47,6 +47,7 @@ class CreateDefinitionAndPrepareArgsRequest(SchemaModel):
     mount_points: List[MountPointTypeDef] = custom_field(default_factory=list)
     volumes: List[VolumeTypeDef] = custom_field(default_factory=list)
     retry_strategy: Optional[RetryStrategyTypeDef] = custom_field(default=None)
+    privileged: bool = custom_field(default=False)
 
 
 @dataclass

--- a/src/aibs_informatics_aws_lambda/handlers/demand/context_manager.py
+++ b/src/aibs_informatics_aws_lambda/handlers/demand/context_manager.py
@@ -605,6 +605,8 @@ def generate_batch_job_builder(
         mount_points=[_.mount_point for _ in vol_configurations],
         volumes=[_.volume for _ in vol_configurations],
         env_base=env_base,
+        # TODO: need to make this configurable
+        privileged=True,
     )
 
 

--- a/src/aibs_informatics_aws_lambda/handlers/demand/scaffolding.py
+++ b/src/aibs_informatics_aws_lambda/handlers/demand/scaffolding.py
@@ -101,6 +101,7 @@ class PrepareDemandScaffoldingHandler(
                 mount_points=batch_job_builder.mount_points,
                 volumes=batch_job_builder.volumes,
                 retry_strategy=build_retry_strategy(num_retries=5),
+                privileged=batch_job_builder.privileged,
             ),
         )
 

--- a/test/aibs_informatics_aws_lambda/handlers/demand/test_context_manager.py
+++ b/test/aibs_informatics_aws_lambda/handlers/demand/test_context_manager.py
@@ -15,7 +15,7 @@ from aibs_informatics_aws_utils.constants.efs import (
     EFS_TMP_ACCESS_POINT_NAME,
     EFS_TMP_PATH,
 )
-from aibs_informatics_aws_utils.efs import MountPointConfiguration
+from aibs_informatics_aws_utils.efs import MountPointConfiguration, detect_mount_points
 from aibs_informatics_core.env import EnvBase
 from aibs_informatics_core.models.aws.efs import EFSPath
 from aibs_informatics_core.models.aws.s3 import S3URI
@@ -316,6 +316,8 @@ class DemandExecutionContextManagerTests(AwsBaseTest, Helpers):
         self.mock_efs.start()
         self.set_aws_credentials()
         self.setUpEFS()
+        # NOTE: detect_mount_points is cached. We need to clear the cache
+        detect_mount_points.cache_clear()
 
     def tearDown(self) -> None:
         self.mock_efs.stop()
@@ -590,7 +592,7 @@ class DemandExecutionContextManagerTests(AwsBaseTest, Helpers):
 
     def test__batch_job_builder__conditional_write_mode__required(self):
         demand_execution = get_any_demand_execution(
-            execution_id=uuid_str("123"),
+            execution_id=uuid_str("1234"),
             execution_parameters=DemandExecutionParameters(
                 command=["cmd", "${ENV_BASE}"],
                 params={

--- a/test/aibs_informatics_aws_lambda/handlers/demand/test_scaffolding.py
+++ b/test/aibs_informatics_aws_lambda/handlers/demand/test_scaffolding.py
@@ -190,6 +190,7 @@ class PrepareDemandScaffoldingHandlerTests(LambdaHandlerTestCase):
         batch_job_builder.resource_requirements = []
         batch_job_builder.mount_points = []
         batch_job_builder.volumes = []
+        batch_job_builder.privileged = False
 
         expected = PrepareDemandScaffoldingResponse(
             demand_execution=self.demand_execution,
@@ -279,6 +280,7 @@ class PrepareDemandScaffoldingHandlerTests(LambdaHandlerTestCase):
         batch_job_builder.resource_requirements = []
         batch_job_builder.mount_points = []
         batch_job_builder.volumes = []
+        batch_job_builder.privileged = False
 
         expected = PrepareDemandScaffoldingResponse(
             demand_execution=self.demand_execution,


### PR DESCRIPTION
## What's in this Change?

If we need to set up fsx file systems in demands and want to set up in the docker command, we will need to enable privileged mode. This (and https://github.com/AllenInstitute/aibs-informatics-aws-utils/pull/7) change enables that.

