### PR TITLE
configure context manager to utilize intermediate_s3_path

### DIFF
--- a/src/aibs_informatics_aws_lambda/handlers/data_sync/operations.py
+++ b/src/aibs_informatics_aws_lambda/handlers/data_sync/operations.py
@@ -205,14 +205,18 @@ class PrepareBatchDataSyncHandler(
                 )
             batch_data_sync_requests.append(BatchDataSyncRequest(requests=data_sync_requests))
 
-        if request.intermediate_s3_path:
-            self.logger.info(f"Uploading batch requests to {request.intermediate_s3_path}")
+        if request.temporary_request_payload_path:
+            self.logger.info(
+                f"Uploading batch requests to {request.temporary_request_payload_path}"
+            )
             new_batch_data_sync_requests = []
 
             for i, batch_data_sync_request in enumerate(batch_data_sync_requests):
                 upload_json(
                     [cast(DataSyncRequest, _).to_dict() for _ in batch_data_sync_request.requests],
-                    s3_path=(s3_path := request.intermediate_s3_path / f"request_{i}.json"),
+                    s3_path=(
+                        s3_path := request.temporary_request_payload_path / f"request_{i}.json"
+                    ),
                 )
                 new_batch_data_sync_requests.append(BatchDataSyncRequest(requests=s3_path))
             return PrepareBatchDataSyncResponse(requests=new_batch_data_sync_requests)

--- a/src/aibs_informatics_aws_lambda/handlers/demand/context_manager.py
+++ b/src/aibs_informatics_aws_lambda/handlers/demand/context_manager.py
@@ -247,7 +247,7 @@ class DemandExecutionContextManager:
                 retain_source_data=True,
                 require_lock=True,
                 batch_size_bytes_limit=75 * BYTES_PER_GIBIBYTE,  # 75 GiB max
-                intermediate_s3_path=self.configuration.input_data_sync_configuration.intermediate_s3_path,
+                temporary_request_payload_path=self.configuration.input_data_sync_configuration.temporary_request_payload_path,
                 size_only=self.configuration.input_data_sync_configuration.size_only,
                 force=self.configuration.input_data_sync_configuration.force,
             )
@@ -263,7 +263,7 @@ class DemandExecutionContextManager:
                 retain_source_data=False,
                 require_lock=False,
                 batch_size_bytes_limit=75 * BYTES_PER_GIBIBYTE,  # 75 GiB max
-                intermediate_s3_path=self.configuration.output_data_sync_configuration.intermediate_s3_path,
+                temporary_request_payload_path=self.configuration.output_data_sync_configuration.temporary_request_payload_path,
                 size_only=self.configuration.output_data_sync_configuration.size_only,
                 force=self.configuration.output_data_sync_configuration.force,
             )

--- a/src/aibs_informatics_aws_lambda/handlers/demand/model.py
+++ b/src/aibs_informatics_aws_lambda/handlers/demand/model.py
@@ -48,7 +48,7 @@ class EnvFileWriteMode(str, Enum):
 
 @dataclass
 class DataSyncConfiguration(SchemaModel):
-    intermediate_s3_path: Optional[S3Path] = custom_field(
+    temporary_request_payload_path: Optional[S3Path] = custom_field(
         default=None, mm_field=S3Path.as_mm_field()
     )
     force: bool = custom_field(default=False)
@@ -62,30 +62,12 @@ class ContextManagerConfiguration(SchemaModel):
         mm_field=EnumField(EnvFileWriteMode), default=EnvFileWriteMode.ALWAYS
     )
     # data sync configurations
-    # DEPRECATED - use input_data_sync_configuration and output_data_sync_configuration instead
-    intermediate_s3_path: Optional[S3Path] = custom_field(
-        default=None, mm_field=S3Path.as_mm_field()
-    )
-    # DEPRECATED - use input_data_sync_configuration and output_data_sync_configuration instead
-    force: bool = custom_field(default=False)
-    # DEPRECATED - use input_data_sync_configuration and output_data_sync_configuration instead
-    size_only: bool = custom_field(default=True)
     input_data_sync_configuration: DataSyncConfiguration = custom_field(
         default_factory=DataSyncConfiguration, mm_field=DataSyncConfiguration.as_mm_field()
     )
     output_data_sync_configuration: DataSyncConfiguration = custom_field(
         default_factory=DataSyncConfiguration, mm_field=DataSyncConfiguration.as_mm_field()
     )
-
-    def __post_init__(self):
-        # TEMPOARY: to support backward compatibility
-        if not (self.intermediate_s3_path is None or self.force is None or self.size_only is None):
-            if self.input_data_sync_configuration.intermediate_s3_path is None:
-                self.input_data_sync_configuration.intermediate_s3_path = self.intermediate_s3_path
-            if self.output_data_sync_configuration.intermediate_s3_path is None:
-                self.output_data_sync_configuration.intermediate_s3_path = (
-                    self.intermediate_s3_path
-                )
 
 
 @dataclass

--- a/test/aibs_informatics_aws_lambda/handlers/data_sync/test_operations.py
+++ b/test/aibs_informatics_aws_lambda/handlers/data_sync/test_operations.py
@@ -220,7 +220,7 @@ class PrepareBatchDataSyncHandlerTests(LambdaHandlerTestCase):
             batch_size_bytes_limit=10,
             max_concurrency=10,
             retain_source_data=True,
-            intermediate_s3_path=S3Path.build(bucket_name="bucket", key="intermediate/"),
+            temporary_request_payload_path=S3Path.build(bucket_name="bucket", key="intermediate/"),
         )
 
         expected_json = [

--- a/test/aibs_informatics_aws_lambda/handlers/demand/test_context_manager.py
+++ b/test/aibs_informatics_aws_lambda/handlers/demand/test_context_manager.py
@@ -38,7 +38,6 @@ from aibs_informatics_aws_lambda.handlers.demand.context_manager import (
     BatchEFSConfiguration,
     DemandExecutionContextManager,
     get_batch_efs_configuration,
-    get_batch_job_queue_name,
     update_demand_execution_parameter_inputs,
 )
 from aibs_informatics_aws_lambda.handlers.demand.model import (
@@ -665,7 +664,7 @@ class DemandExecutionContextManagerTests(AwsBaseTest, Helpers):
         self.assertEqual(expected["source_path"], actual_dict.get("source_path"))
         self.assertEqual(expected["destination_path"], actual_dict.get("destination_path"))
         self.assertEqual(expected["retain_source_data"], actual_dict.get("retain_source_data"))
-        self.assertIsNone(actual_dict.get("intermediate_s3_path"))
+        self.assertIsNone(actual_dict.get("temporary_request_payload_path"))
 
     def test__pre_execution_data_sync_requests__single_input_generates_list__with_data_sync_request_overrides(
         self,
@@ -680,7 +679,7 @@ class DemandExecutionContextManagerTests(AwsBaseTest, Helpers):
             self.env_base,
             ContextManagerConfiguration(
                 input_data_sync_configuration=DataSyncConfiguration(
-                    intermediate_s3_path=S3URI("s3://bucket/override_prefix")
+                    temporary_request_payload_path=S3URI("s3://bucket/override_prefix")
                 )
             ),
         )
@@ -690,7 +689,7 @@ class DemandExecutionContextManagerTests(AwsBaseTest, Helpers):
             "retain_source_data": True,
             "source_path": S3_URI,
             "destination_path": f"{self.gwo_file_system_id}:/shared/558ca1533e03aaea2e3fb825be29124c1648046a2893052d1a1df0059becbf4f",
-            "intermediate_s3_path": "s3://bucket/override_prefix",
+            "temporary_request_payload_path": "s3://bucket/override_prefix",
         }
         self.assertTrue(len(actual) == 1)
         actual_dict = actual[0].to_dict()
@@ -698,7 +697,10 @@ class DemandExecutionContextManagerTests(AwsBaseTest, Helpers):
         self.assertEqual(expected["source_path"], actual_dict.get("source_path"))
         self.assertEqual(expected["destination_path"], actual_dict.get("destination_path"))
         self.assertEqual(expected["retain_source_data"], actual_dict.get("retain_source_data"))
-        self.assertEqual(expected["intermediate_s3_path"], actual_dict.get("intermediate_s3_path"))
+        self.assertEqual(
+            expected["temporary_request_payload_path"],
+            actual_dict.get("temporary_request_payload_path"),
+        )
 
     def test__post_execution_data_sync_requests__no_outputs_generate_empty_list(self):
         demand_execution = get_any_demand_execution(
@@ -742,7 +744,7 @@ class DemandExecutionContextManagerTests(AwsBaseTest, Helpers):
             self.env_base,
             ContextManagerConfiguration(
                 output_data_sync_configuration=DataSyncConfiguration(
-                    intermediate_s3_path=S3URI("s3://bucket/override_prefix")
+                    temporary_request_payload_path=S3URI("s3://bucket/override_prefix")
                 )
             ),
         )
@@ -752,14 +754,17 @@ class DemandExecutionContextManagerTests(AwsBaseTest, Helpers):
             "retain_source_data": False,
             "source_path": f"{self.gwo_file_system_id}:/scratch/{demand_execution.execution_id}/outs",
             "destination_path": f"{S3_URI}/outs",
-            "intermediate_s3_path": "s3://bucket/override_prefix",
+            "temporary_request_payload_path": "s3://bucket/override_prefix",
         }
         self.assertTrue(len(actual) == 1)
         actual_dict = actual[0].to_dict()
         self.assertEqual(expected["source_path"], actual_dict.get("source_path"))
         self.assertEqual(expected["destination_path"], actual_dict.get("destination_path"))
         self.assertEqual(expected["retain_source_data"], actual_dict.get("retain_source_data"))
-        self.assertEqual(expected["intermediate_s3_path"], actual_dict.get("intermediate_s3_path"))
+        self.assertEqual(
+            expected["temporary_request_payload_path"],
+            actual_dict.get("temporary_request_payload_path"),
+        )
 
     def test__batch_job_queue_name__works_for_valid_demand_execution(self):
         demand_execution = get_any_demand_execution(

--- a/test/aibs_informatics_aws_lambda/handlers/demand/test_scaffolding.py
+++ b/test/aibs_informatics_aws_lambda/handlers/demand/test_scaffolding.py
@@ -62,8 +62,14 @@ class PrepareDemandScaffoldingHandlerTests(LambdaHandlerTestCase):
             "context_manager_configuration": {
                 "isolate_inputs": True,
                 "env_file_write_mode": "NEVER",
-                "force": False,
-                "size_only": True,
+                "input_data_sync_configuration": {
+                    "force": False,
+                    "size_only": True,
+                },
+                "output_data_sync_configuration": {
+                    "force": False,
+                    "size_only": True,
+                },
             },
         }
 
@@ -80,8 +86,6 @@ class PrepareDemandScaffoldingHandlerTests(LambdaHandlerTestCase):
             context_manager_configuration=ContextManagerConfiguration(
                 isolate_inputs=True,
                 env_file_write_mode=EnvFileWriteMode.NEVER,
-                force=False,
-                size_only=True,
             ),
         )
         assert actual == expected


### PR DESCRIPTION
## What's in this Change?

This change makes it possible to configure `DemandExecutionContextManager` to have more control over the data sync requests for inputs and outputs that are generated.  

## Testing
added unit tests 
