### PR TITLE
Carry over missed parameters from PrepareBatchDataSyncRequest to DataSyncRequest

### DIFF
--- a/src/aibs_informatics_aws_lambda/handlers/data_sync/operations.py
+++ b/src/aibs_informatics_aws_lambda/handlers/data_sync/operations.py
@@ -201,6 +201,11 @@ class PrepareBatchDataSyncHandler(
                         max_concurrency=request.max_concurrency,
                         retain_source_data=request.retain_source_data,
                         require_lock=request.require_lock,
+                        force=request.force,
+                        size_only=request.size_only,
+                        fail_if_missing=request.fail_if_missing,
+                        include_detailed_response=request.include_detailed_response,
+                        remote_to_local_config=request.remote_to_local_config,
                     )
                 )
             batch_data_sync_requests.append(BatchDataSyncRequest(requests=data_sync_requests))

--- a/test/aibs_informatics_aws_lambda/handlers/data_sync/test_operations.py
+++ b/test/aibs_informatics_aws_lambda/handlers/data_sync/test_operations.py
@@ -206,6 +206,43 @@ class PrepareBatchDataSyncHandlerTests(LambdaHandlerTestCase):
         )
         self.assertHandles(self.handler, request.to_dict(), expected.to_dict())
 
+    def test__handle__prepare_local_to_s3__simple__non_default_args_preserved(self):
+        fs = self.setUpLocalFS(
+            ("a", 1),
+            ("b", 1),
+            ("c", 1),
+        )
+        source_path = fs
+        destination_path = S3Path.build(bucket_name="bucket", key="key/")
+        request = PrepareBatchDataSyncRequest(
+            source_path=source_path,
+            destination_path=destination_path,
+            batch_size_bytes_limit=10,
+            max_concurrency=10,
+            retain_source_data=True,
+            size_only=True,
+            force=True,
+            include_detailed_response=True,
+        )
+        expected = PrepareBatchDataSyncResponse(
+            requests=[
+                BatchDataSyncRequest(
+                    requests=[
+                        DataSyncRequest(
+                            source_path=source_path,
+                            destination_path=destination_path,
+                            max_concurrency=10,
+                            retain_source_data=True,
+                            size_only=True,
+                            force=True,
+                            include_detailed_response=True,
+                        )
+                    ]
+                )
+            ]
+        )
+        self.assertHandles(self.handler, request.to_dict(), expected.to_dict())
+
     def test__handle__prepare_local_to_s3__simple__upload_to_s3(self):
         fs = self.setUpLocalFS(
             ("a", 1),


### PR DESCRIPTION
## What's in this Change?

In our merscope analysis pipeline, we discovered that some settings for data sync were not copied over properly during the prep step in our distributed data sync workflow. 

This change addresses the missed parameters and now carries them over to the nested data sync requests. 

related to https://github.com/AllenInstitute/aibs-informatics-aws-utils/pull/28/files

## Testing

* adding test to cover this explicitly

