### PR TITLE
feature/add gh action to promote docker image to registry

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,69 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - 'v*'
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up AllenInstitute Repo Authorization
+        uses: ./.github/actions/configure-org-repo-authorization
+        with:
+          token: ${{ secrets.AI_PACKAGES_TOKEN }}
+          ssh_private_key: ${{ secrets.AIBSGITHUB_PRIVATE_KEY }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          ssh: default=${{ env.SSH_AUTH_SOCK }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,12 +1,13 @@
 name: Build and Publish Docker Image
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Build and Test"]
+    types: [completed]
     branches: [main]
+  push:
     tags:
       - 'v*'
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 env:
@@ -18,6 +19,10 @@ jobs:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Only run if triggered manually, by tag, or if the test workflow succeeded
+    if: >
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
     permissions:
       contents: read
       packages: write
@@ -36,7 +41,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -49,8 +53,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha
@@ -61,7 +65,7 @@ jobs:
           context: .
           file: ./docker/Dockerfile
           platforms: linux/amd64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           ssh: default=${{ env.SSH_AUTH_SOCK }}

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -32,6 +32,12 @@ on:
   # Allow manual trigger for debugging or re-running failed builds.
   workflow_dispatch:
 
+# Prevent out-of-order publishing when multiple workflow_run events complete.
+# If a newer run starts while an older one is in progress, cancel the older one.
+concurrency:
+  group: docker-publish-${{ github.event.workflow_run.head_branch || github.ref_name }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -54,8 +60,12 @@ jobs:
       packages: write     # Required to push to GitHub Container Registry
 
     steps:
+      # For workflow_run events, checkout the SHA that was actually tested,
+      # not the current HEAD (which may have moved). For other events, use github.sha.
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       # Configure SSH agent and git credentials for accessing private
       # AllenInstitute repositories during the Docker build.

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -3,6 +3,7 @@
 # This workflow is gated on successful tests:
 #   - For pushes to main: waits for "Build and Test" workflow to complete successfully
 #   - For version tags (v*): runs directly (assumes tag is cut from tested code)
+#   - For pull requests: builds only (no push) to validate Dockerfile before merge
 #   - For manual dispatch: runs directly (operator takes responsibility)
 #
 # Published images are available at: ghcr.io/<owner>/aibs-informatics-aws-lambda
@@ -23,6 +24,10 @@ on:
   push:
     tags:
       - 'v*'
+
+  # Build (but don't push) on pull requests to validate the Dockerfile.
+  pull_request:
+    branches: [main]
 
   # Allow manual trigger for debugging or re-running failed builds.
   workflow_dispatch:
@@ -64,7 +69,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # Skip login for PRs since we won't push the image.
       - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -74,6 +81,7 @@ jobs:
       # Generate Docker tags based on git context:
       #   - "latest" for default branch (main)
       #   - branch name (e.g., "main")
+      #   - PR number (e.g., "pr-123") - used for build validation only
       #   - semver tags (e.g., "1.2.3", "1.2")
       #   - short SHA (e.g., "sha-abc1234")
       - name: Extract metadata (tags, labels)
@@ -84,17 +92,19 @@ jobs:
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=branch
+            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha
 
+      # Build the image; only push for non-PR events.
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/Dockerfile
           platforms: linux/amd64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # Forward SSH agent to builder for private repo access during build

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -1,13 +1,30 @@
+# Builds and publishes Docker image to GitHub Container Registry (ghcr.io)
+#
+# This workflow is gated on successful tests:
+#   - For pushes to main: waits for "Build and Test" workflow to complete successfully
+#   - For version tags (v*): runs directly (assumes tag is cut from tested code)
+#   - For manual dispatch: runs directly (operator takes responsibility)
+#
+# Published images are available at: ghcr.io/<owner>/aibs-informatics-aws-lambda
+
 name: Build and Publish Docker Image
 
 on:
+  # Trigger after the test workflow completes on main branch.
+  # Note: workflow_run triggers on completion (success OR failure), so we check
+  # the conclusion in the job's `if` condition below.
   workflow_run:
     workflows: ["Build and Test"]
     types: [completed]
     branches: [main]
+
+  # Version tags trigger directly (no test gate) - assumes tags are cut from
+  # tested commits on main.
   push:
     tags:
       - 'v*'
+
+  # Allow manual trigger for debugging or re-running failed builds.
   workflow_dispatch:
 
 env:
@@ -19,24 +36,31 @@ jobs:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Only run if triggered manually, by tag, or if the test workflow succeeded
+
+    # Gate logic:
+    #   - workflow_run events: only proceed if the triggering workflow succeeded
+    #   - tag pushes / manual dispatch: always proceed (no workflow_run event)
     if: >
       github.event_name != 'workflow_run' ||
       github.event.workflow_run.conclusion == 'success'
+
     permissions:
-      contents: read
-      packages: write
+      contents: read      # Required to checkout the repository
+      packages: write     # Required to push to GitHub Container Registry
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # Configure SSH agent and git credentials for accessing private
+      # AllenInstitute repositories during the Docker build.
       - name: Set up AllenInstitute Repo Authorization
         uses: ./.github/actions/configure-org-repo-authorization
         with:
           token: ${{ secrets.AI_PACKAGES_TOKEN }}
           ssh_private_key: ${{ secrets.AIBSGITHUB_PRIVATE_KEY }}
 
+      # Buildx enables advanced features like caching and multi-platform builds.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -47,6 +71,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Generate Docker tags based on git context:
+      #   - "latest" for default branch (main)
+      #   - branch name (e.g., "main")
+      #   - semver tags (e.g., "1.2.3", "1.2")
+      #   - short SHA (e.g., "sha-abc1234")
       - name: Extract metadata (tags, labels)
         id: meta
         uses: docker/metadata-action@v5
@@ -68,6 +97,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Forward SSH agent to builder for private repo access during build
+          # (used by `RUN --mount=type=ssh` in Dockerfile)
           ssh: default=${{ env.SSH_AUTH_SOCK }}
+          # Use GitHub Actions cache for Docker layers to speed up rebuilds
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -59,6 +59,7 @@ jobs:
 
       # Configure SSH agent and git credentials for accessing private
       # AllenInstitute repositories during the Docker build.
+      # This step is optional - the composite action handles missing secrets gracefully.
       - name: Set up AllenInstitute Repo Authorization
         uses: ./.github/actions/configure-org-repo-authorization
         with:
@@ -108,8 +109,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # Forward SSH agent to builder for private repo access during build
-          # (used by `RUN --mount=type=ssh` in Dockerfile)
-          ssh: default=${{ env.SSH_AUTH_SOCK }}
+          # (used by `RUN --mount=type=ssh` in Dockerfile). Only set if SSH agent is available.
+          ssh: ${{ env.SSH_AUTH_SOCK && format('default={0}', env.SSH_AUTH_SOCK) || '' }}
           # Use GitHub Actions cache for Docker layers to speed up rebuilds
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -63,7 +63,7 @@ jobs:
       # For workflow_run events, checkout the SHA that was actually tested,
       # not the current HEAD (which may have moved). For other events, use github.sha.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
@@ -78,7 +78,7 @@ jobs:
 
       # Buildx enables advanced features like caching and multi-platform builds.
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Skip login for PRs since we won't push the image.
       - name: Log in to GitHub Container Registry


### PR DESCRIPTION


## What's in this Change?

Adds a new GitHub Actions workflow to build and publish a Docker image to GitHub Container Registry (GHCR), with publishing gated on successful completion of the existing “Build and Test” workflow for `main` and direct publishing for version tags / manual dispatch.

This will help simplify consuming the docker image directly instead of having to rebuild

**Changes:**
- Introduces `.github/workflows/publish_docker.yml` to build and push a Docker image to `ghcr.io`.
- Uses `workflow_run` to gate publishing on successful test workflow completion for `main`.
- Adds Docker metadata-based tagging and GitHub Actions cache configuration for faster rebuilds.

## Testing

- Build step is included in PR checks (run only after build and test succeeds)
