### PR TITLE
Support multiple EFS file system candidates in demand scaffolding

### DIFF
--- a/src/aibs_informatics_aws_lambda/handlers/demand/model.py
+++ b/src/aibs_informatics_aws_lambda/handlers/demand/model.py
@@ -10,7 +10,7 @@ from aibs_informatics_core.models.aws.s3 import S3Path
 from aibs_informatics_core.models.base import PydanticBaseModel
 from aibs_informatics_core.models.data_sync import DataSyncRequest, PrepareBatchDataSyncRequest
 from aibs_informatics_core.models.demand_execution import DemandExecution
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from aibs_informatics_aws_lambda.handlers.batch.model import CreateDefinitionAndPrepareArgsRequest
 from aibs_informatics_aws_lambda.handlers.data_sync.model import RemoveDataPathsRequest
@@ -30,18 +30,58 @@ class FileSystemConfiguration(PydanticBaseModel):
     container_path: str | None = None
 
 
+class FileSystemSelectionStrategy(str, Enum):
+    """Strategy for selecting one file system from a list of candidates.
+
+    Attributes:
+        RANDOM: Uniform random selection, seeded with the demand execution ID
+            so that the same execution always resolves to the same candidate.
+    """
+
+    RANDOM = "RANDOM"
+
+
 class DemandFileSystemConfigurations(PydanticBaseModel):
     """Collection of file system configurations for demand execution.
 
+    Each volume role accepts a list of candidate configurations; the scaffolding
+    handler selects exactly one candidate per role (per ``selection_strategy``)
+    for a given demand execution. A single (non-list) configuration is accepted
+    for backwards compatibility and coerced to a one-element list.
+
     Attributes:
-        shared: Configuration for the shared/input volume (read-only).
-        scratch: Configuration for the scratch/working volume (read-write).
-        tmp: Optional configuration for a dedicated tmp volume.
+        shared: Candidate configurations for the shared/input volume (read-only).
+        scratch: Candidate configurations for the scratch/working volume (read-write).
+        tmp: Candidate configurations for a dedicated tmp volume. An empty list
+            means no dedicated tmp volume is used.
+        selection_strategy: Strategy used to select one candidate per role.
     """
 
-    shared: FileSystemConfiguration = Field(default_factory=FileSystemConfiguration)
-    scratch: FileSystemConfiguration = Field(default_factory=FileSystemConfiguration)
-    tmp: FileSystemConfiguration | None = None
+    shared: list[FileSystemConfiguration] = Field(
+        default_factory=lambda: [FileSystemConfiguration()]
+    )
+    scratch: list[FileSystemConfiguration] = Field(
+        default_factory=lambda: [FileSystemConfiguration()]
+    )
+    tmp: list[FileSystemConfiguration] = Field(default_factory=list)
+    selection_strategy: FileSystemSelectionStrategy = FileSystemSelectionStrategy.RANDOM
+
+    @field_validator("shared", "scratch", "tmp", mode="before")
+    @classmethod
+    def _coerce_single_to_list(cls, value):
+        """Coerce a legacy single configuration (or None) into a list."""
+        if value is None:
+            return []
+        if not isinstance(value, list):
+            return [value]
+        return value
+
+    @field_validator("shared", "scratch")
+    @classmethod
+    def _require_non_empty(cls, value, info):
+        if not value:
+            raise ValueError(f"At least one {info.field_name} file system config is required")
+        return value
 
 
 class EnvFileWriteMode(str, Enum):

--- a/src/aibs_informatics_aws_lambda/handlers/demand/scaffolding.py
+++ b/src/aibs_informatics_aws_lambda/handlers/demand/scaffolding.py
@@ -4,6 +4,7 @@ Provides Lambda handlers for preparing demand execution scaffolding,
 including file system setup and batch job configuration.
 """
 
+import random
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -28,6 +29,8 @@ from aibs_informatics_aws_lambda.handlers.demand.model import (
     CreateDefinitionAndPrepareArgsRequest,
     DemandExecutionCleanupConfigs,
     DemandExecutionSetupConfigs,
+    FileSystemConfiguration,
+    FileSystemSelectionStrategy,
     PrepareDemandScaffoldingRequest,
     PrepareDemandScaffoldingResponse,
 )
@@ -66,39 +69,62 @@ class PrepareDemandScaffoldingHandler(
             Response containing the updated demand execution and
             setup/cleanup configurations.
         """
+        file_system_configurations = request.file_system_configurations
+        selection_strategy = file_system_configurations.selection_strategy
+        # Seed selection with the execution id so that resubmissions of the same demand
+        # execution resolve to the same file systems (working dir, cache and cleanup paths
+        # stay consistent across retries). The seed is salted per role so that shared/
+        # scratch/tmp selections are independent of each other.
+        execution_id = request.demand_execution.execution_id
+
+        scratch_fs_config = select_file_system(
+            file_system_configurations.scratch,
+            selection_strategy=selection_strategy,
+            seed=f"{execution_id}#scratch",
+        )
         scratch_vol_configuration = construct_batch_efs_configuration(
             env_base=self.env_base,
-            file_system=request.file_system_configurations.scratch.file_system,
-            access_point=request.file_system_configurations.scratch.access_point
-            if request.file_system_configurations.scratch.access_point
+            file_system=scratch_fs_config.file_system,
+            access_point=scratch_fs_config.access_point
+            if scratch_fs_config.access_point
             else EFS_SCRATCH_ACCESS_POINT_NAME,
-            container_path=request.file_system_configurations.scratch.container_path
-            if request.file_system_configurations.scratch.container_path
+            container_path=scratch_fs_config.container_path
+            if scratch_fs_config.container_path
             else f"/opt/efs{EFS_SCRATCH_PATH}",
             read_only=False,
         )
 
+        shared_fs_config = select_file_system(
+            file_system_configurations.shared,
+            selection_strategy=selection_strategy,
+            seed=f"{execution_id}#shared",
+        )
         shared_vol_configuration = construct_batch_efs_configuration(
             env_base=self.env_base,
-            file_system=request.file_system_configurations.shared.file_system,
-            access_point=request.file_system_configurations.shared.access_point
-            if request.file_system_configurations.shared.access_point
+            file_system=shared_fs_config.file_system,
+            access_point=shared_fs_config.access_point
+            if shared_fs_config.access_point
             else EFS_SHARED_ACCESS_POINT_NAME,
-            container_path=request.file_system_configurations.shared.container_path
-            if request.file_system_configurations.shared.container_path
+            container_path=shared_fs_config.container_path
+            if shared_fs_config.container_path
             else f"/opt/efs{EFS_SHARED_PATH}",
             read_only=True,
         )
 
-        if request.file_system_configurations.tmp is not None:
+        if file_system_configurations.tmp:
+            tmp_fs_config = select_file_system(
+                file_system_configurations.tmp,
+                selection_strategy=selection_strategy,
+                seed=f"{execution_id}#tmp",
+            )
             tmp_vol_configuration = construct_batch_efs_configuration(
                 env_base=self.env_base,
-                file_system=request.file_system_configurations.tmp.file_system,
-                access_point=request.file_system_configurations.tmp.access_point
-                if request.file_system_configurations.tmp.access_point
+                file_system=tmp_fs_config.file_system,
+                access_point=tmp_fs_config.access_point
+                if tmp_fs_config.access_point
                 else EFS_TMP_ACCESS_POINT_NAME,
-                container_path=request.file_system_configurations.tmp.container_path
-                if request.file_system_configurations.tmp.container_path
+                container_path=tmp_fs_config.container_path
+                if tmp_fs_config.container_path
                 else f"/opt/efs{EFS_TMP_PATH}",
                 read_only=False,
             )
@@ -160,6 +186,44 @@ class PrepareDemandScaffoldingHandler(
         """
         working_path = context_manager.container_working_path  # noqa: F841
         # working_path.mkdir(parents=True, exist_ok=True)
+
+
+def select_file_system(
+    file_system_configurations: list[FileSystemConfiguration],
+    selection_strategy: FileSystemSelectionStrategy,
+    seed: str | int | None = None,
+) -> FileSystemConfiguration:
+    """Select one file system configuration from a list of candidates.
+
+    Supported strategies:
+        RANDOM: Uniform random choice over the candidates. When ``seed`` is provided,
+            a dedicated ``random.Random(seed)`` instance is used so the choice is
+            deterministic for that seed (callers pass the demand execution id, making
+            placement stable across resubmissions of the same execution). A dedicated
+            instance also keeps selections for different roles (shared/scratch/tmp)
+            independent of global random state.
+
+    Args:
+        file_system_configurations (list[FileSystemConfiguration]): Candidate configs.
+        selection_strategy (FileSystemSelectionStrategy): Strategy to select with.
+        seed (str | int | None): Optional seed for deterministic selection.
+
+    Returns:
+        The selected file system configuration.
+
+    Raises:
+        ValueError: If no candidates are provided or the strategy is unknown.
+    """
+    if len(file_system_configurations) == 0:
+        raise ValueError("No file system configurations provided")
+    if len(file_system_configurations) == 1:
+        return file_system_configurations[0]
+
+    if selection_strategy == FileSystemSelectionStrategy.RANDOM:
+        rng = random.Random(seed) if seed is not None else random.Random()
+        return rng.choice(file_system_configurations)
+
+    raise ValueError(f"Unknown selection strategy: {selection_strategy}")
 
 
 def construct_batch_efs_configuration(

--- a/test/aibs_informatics_aws_lambda/handlers/demand/test_model.py
+++ b/test/aibs_informatics_aws_lambda/handlers/demand/test_model.py
@@ -1,9 +1,13 @@
+from aibs_informatics_core.exceptions import ValidationError
 from aibs_informatics_core.models.aws.s3 import S3Path
-from pytest import mark, param
+from pytest import mark, param, raises
 
 from aibs_informatics_aws_lambda.handlers.data_sync.model import RemoveDataPathsRequest
 from aibs_informatics_aws_lambda.handlers.demand.model import (
     DemandExecutionCleanupConfigs,
+    DemandFileSystemConfigurations,
+    FileSystemConfiguration,
+    FileSystemSelectionStrategy,
     PrepareBatchDataSyncRequest,
 )
 from test.base import does_not_raise
@@ -166,3 +170,76 @@ def test__DemandExecutionCleanupConfigs__deserialization(
         actual = DemandExecutionCleanupConfigs.from_dict(input_value)
     if expected:
         assert expected == actual
+
+
+def test__DemandFileSystemConfigurations__defaults_preserve_legacy_behavior():
+    configs = DemandFileSystemConfigurations()
+    assert configs.shared == [FileSystemConfiguration()]
+    assert configs.scratch == [FileSystemConfiguration()]
+    assert configs.tmp == []
+    assert configs.selection_strategy == FileSystemSelectionStrategy.RANDOM
+
+
+def test__DemandFileSystemConfigurations__coerces_legacy_singular_shape():
+    configs = DemandFileSystemConfigurations.from_dict(
+        {
+            "shared": {"file_system": "fs-shared"},
+            "scratch": {"file_system": "fs-scratch"},
+            "tmp": {"file_system": "fs-tmp"},
+        }
+    )
+    assert configs.shared == [FileSystemConfiguration(file_system="fs-shared")]
+    assert configs.scratch == [FileSystemConfiguration(file_system="fs-scratch")]
+    assert configs.tmp == [FileSystemConfiguration(file_system="fs-tmp")]
+
+
+def test__DemandFileSystemConfigurations__accepts_null_tmp():
+    configs = DemandFileSystemConfigurations.from_dict(
+        {
+            "shared": {"file_system": "fs-shared"},
+            "scratch": {"file_system": "fs-scratch"},
+            "tmp": None,
+        }
+    )
+    assert configs.tmp == []
+
+
+def test__DemandFileSystemConfigurations__accepts_candidate_lists():
+    configs = DemandFileSystemConfigurations.from_dict(
+        {
+            "shared": [{"file_system": "fs-shared"}],
+            "scratch": [
+                {"file_system": "fs-scratch-1"},
+                {"file_system": "fs-scratch-2"},
+            ],
+            "selection_strategy": "RANDOM",
+        }
+    )
+    assert configs.shared == [FileSystemConfiguration(file_system="fs-shared")]
+    assert configs.scratch == [
+        FileSystemConfiguration(file_system="fs-scratch-1"),
+        FileSystemConfiguration(file_system="fs-scratch-2"),
+    ]
+    assert configs.selection_strategy == FileSystemSelectionStrategy.RANDOM
+
+
+@mark.parametrize("field_name", ["shared", "scratch"])
+def test__DemandFileSystemConfigurations__rejects_empty_required_roles(field_name):
+    with raises(ValidationError):
+        DemandFileSystemConfigurations.from_dict({field_name: []})
+
+
+def test__DemandFileSystemConfigurations__serializes_as_lists():
+    configs = DemandFileSystemConfigurations.from_dict(
+        {
+            "shared": {"file_system": "fs-shared"},
+            "scratch": [{"file_system": "fs-scratch-1"}, {"file_system": "fs-scratch-2"}],
+        }
+    )
+    data = configs.to_dict()
+    assert data["shared"] == [{"file_system": "fs-shared"}]
+    assert data["scratch"] == [
+        {"file_system": "fs-scratch-1"},
+        {"file_system": "fs-scratch-2"},
+    ]
+    assert data["selection_strategy"] == "RANDOM"

--- a/test/aibs_informatics_aws_lambda/handlers/demand/test_scaffolding.py
+++ b/test/aibs_informatics_aws_lambda/handlers/demand/test_scaffolding.py
@@ -17,6 +17,7 @@ from aibs_informatics_aws_lambda.handlers.demand.model import (
     DemandFileSystemConfigurations,
     EnvFileWriteMode,
     FileSystemConfiguration,
+    FileSystemSelectionStrategy,
     PrepareBatchDataSyncRequest,
     PrepareDemandScaffoldingRequest,
     PrepareDemandScaffoldingResponse,
@@ -24,6 +25,7 @@ from aibs_informatics_aws_lambda.handlers.demand.model import (
 from aibs_informatics_aws_lambda.handlers.demand.scaffolding import (
     PrepareDemandScaffoldingHandler,
     construct_batch_efs_configuration,
+    select_file_system,
 )
 from test.aibs_informatics_aws_lambda.base import LambdaHandlerTestCase
 from test.aibs_informatics_aws_lambda.handlers.demand.test_context_manager import (
@@ -400,3 +402,107 @@ class PrepareDemandScaffoldingHandlerTests(LambdaHandlerTestCase):
                 {"Key": "Name", "Value": "value"},
             ],
         }
+
+
+class SelectFileSystemTests(PrepareDemandScaffoldingHandlerTests):
+    """Multi-candidate selection tests.
+
+    Inherits setUp/helpers from PrepareDemandScaffoldingHandlerTests (re-running the
+    inherited single-candidate tests in this class is harmless).
+    """
+
+    def candidates(self, count: int) -> list[FileSystemConfiguration]:
+        return [FileSystemConfiguration(file_system=f"fs-{i:012d}") for i in range(count)]
+
+    def test__select_file_system__raises_on_empty_candidates(self) -> None:
+        with self.assertRaises(ValueError):
+            select_file_system([], FileSystemSelectionStrategy.RANDOM)
+
+    def test__select_file_system__single_candidate_returned_directly(self) -> None:
+        candidates = self.candidates(1)
+        selected = select_file_system(candidates, FileSystemSelectionStrategy.RANDOM)
+        assert selected is candidates[0]
+
+    def test__select_file_system__random_is_deterministic_per_seed(self) -> None:
+        candidates = self.candidates(5)
+        first = select_file_system(
+            candidates, FileSystemSelectionStrategy.RANDOM, seed="exec-123#scratch"
+        )
+        for _ in range(10):
+            assert first == select_file_system(
+                candidates, FileSystemSelectionStrategy.RANDOM, seed="exec-123#scratch"
+            )
+
+    def test__select_file_system__random_spreads_across_seeds(self) -> None:
+        candidates = self.candidates(5)
+        selections = {
+            select_file_system(
+                candidates, FileSystemSelectionStrategy.RANDOM, seed=f"exec-{i}#scratch"
+            ).file_system
+            for i in range(50)
+        }
+        assert len(selections) > 1
+
+    @mock.patch(
+        "aibs_informatics_aws_lambda.handlers.demand.scaffolding.construct_batch_efs_configuration"
+    )
+    def test__handle__selects_one_candidate_per_role_deterministically(
+        self, mock_construct_batch_efs_configuration
+    ) -> None:
+        mock_construct_batch_efs_configuration.side_effect = lambda *args, **kwargs: (
+            BatchEFSConfiguration(
+                mount_point_config=MountPointConfiguration(
+                    file_system=self.get_file_system("fs-123456789012"),
+                    access_point=self.get_access_point("fsap-123456789012", "fs-123456789012"),
+                    mount_point=Path("/opt/efs"),
+                ),
+                read_only=False,
+            )
+        )
+        context_manager = mock.MagicMock()
+        self.mock_DemandExecutionContextManager.return_value = context_manager
+        context_manager.demand_execution = self.demand_execution
+        context_manager.pre_execution_data_sync_requests = []
+        context_manager.post_execution_data_sync_requests = []
+        context_manager.post_execution_remove_data_paths_requests = []
+        batch_job_builder = mock.MagicMock()
+        context_manager.batch_job_builder = batch_job_builder
+        context_manager.batch_job_queue_name = "job_queue_name"
+        batch_job_builder.image = "image"
+        batch_job_builder.job_definition_name = "job_definition_name"
+        batch_job_builder.job_name = "job_name"
+        batch_job_builder.job_definition_tags = {}
+        batch_job_builder.command = ["command"]
+        batch_job_builder.environment = {"key": "value"}
+        batch_job_builder.resource_requirements = []
+        batch_job_builder.mount_points = []
+        batch_job_builder.volumes = []
+        batch_job_builder.privileged = False
+        batch_job_builder.job_role_arn = None
+
+        scratch_candidates = [
+            {"file_system": f"fs-{i:012d}", "container_path": "/opt/efs/scratch"} for i in range(4)
+        ]
+        request = {
+            "demand_execution": self.demand_execution.to_dict(),
+            "file_system_configurations": {
+                "scratch": scratch_candidates,
+                "shared": {"file_system": "fs-999999999999"},
+            },
+        }
+
+        call_args_per_invocation = []
+        for _ in range(2):
+            mock_construct_batch_efs_configuration.reset_mock()
+            self.handler(request, self.context)
+            call_args_per_invocation.append(
+                list(mock_construct_batch_efs_configuration.call_args_list)
+            )
+
+        # Same execution id => identical selections across invocations
+        assert call_args_per_invocation[0] == call_args_per_invocation[1]
+
+        scratch_call, shared_call = call_args_per_invocation[0]
+        selected_scratch_fs = scratch_call.kwargs["file_system"]
+        assert selected_scratch_fs in {c["file_system"] for c in scratch_candidates}
+        assert shared_call.kwargs["file_system"] == "fs-999999999999"


### PR DESCRIPTION
## Summary

Concurrent demand executions handling 200GB–1TB of data can exhaust a single bursting-mode EFS file system's throughput. This PR lets the demand scaffolding contract carry **multiple candidate file systems per volume role**, with the scaffolding handler selecting one candidate per role at execution time — so each execution's working-directory I/O lands on one file system out of a pool.

- `DemandFileSystemConfigurations.shared/scratch/tmp` are now `list[FileSystemConfiguration]`; a `mode="before"` field validator coerces the legacy singular shape (and `tmp: null`) into lists, so **existing callers and deployed state machines keep working unchanged**
- New `selection_strategy` field — `RANDOM` only for now; the enum leaves room for utilization-aware strategies later without another contract change
- Selection is seeded with the demand execution id, **salted per role** (`{execution_id}#scratch`, `#shared`, `#tmp`): resubmissions of the same execution deterministically resolve to the same file systems (working dir, cache, and cleanup paths stay consistent across retries), while the three role selections stay independent of each other
- Selected configs keep the existing named-access-point / container-path fallbacks, so behavior for empty configs is unchanged
- Everything downstream (batch job mounts, data-sync requests, cleanup paths) already derives from the scaffolding response, so per-execution affinity propagates automatically

Supersedes [`feature/demand-execution-support-for-multi-efs`](https://github.com/AllenInstitute/aibs-informatics-aws-lambda/tree/feature/demand-execution-support-for-multi-efs) (v1 branch), which predates the pydantic migration (marshmallow `@pre_load` etc.); this is that branch's design reworked onto current `main`. The `SizeInBytes`-based `LEAST_UTILIZED` strategy from that branch was dropped: storage used is the wrong proxy for throughput headroom (in bursting mode, baseline throughput *scales with* stored bytes).

## Sequencing

Merge this **before** the companion aibs-informatics-cdk-lib PR — the CDK app builds the docker image from this repo's `main` at synth time. Single-candidate requests remain wire-identical, so this change is safe to merge and deploy independently.

## Test plan

- [x] All existing tests pass unchanged (the legacy singular-shape tests double as the backward-compat proof)
- [x] New model tests: singular→list coercion, `tmp: null`, omission defaults, empty-list rejection for shared/scratch, list serialization
- [x] New selection tests: empty-candidates error, single-candidate passthrough, per-seed determinism, spread across seeds, end-to-end handler test proving identical placement across two invocations with the same execution id
- [x] `make lint` (ruff + mypy) and full suite: 157 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
